### PR TITLE
temporary fix for missing javascript

### DIFF
--- a/_includes/script.html
+++ b/_includes/script.html
@@ -8,5 +8,5 @@
 <script src="{{ "/assets/shariff/shariff.min.js" | relative_url }}"></script>
 
 {% for js in page.jsarr %}
-<script src="{{ '/assets/js/' | relative_url }}{% if jekyll.environment == 'production' %}{{ js | replace: '.js', '.min.js' }}{% else %}{{ js }}{% endif %}"></script>
+<script src="{{ '/assets/js/' | relative_url }}{{ js }}"></script>
 {% endfor %}


### PR DESCRIPTION
In GitLab, the CI sent some of the Javascript files through a minifier before the jekyll build. In order for the diagrams and contact form to be usable at all, reference is now made to the original javascript files. But in the near future the minifier should be run again via github action.